### PR TITLE
Enable launching ImageJFX from the command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>net.imagej</groupId>
             <artifactId>imagej</artifactId>
-            <version>2.0.0-rc-45-SNAPSHOT</version>
+            <version>2.0.0-rc-45</version>
         </dependency>
         <dependency>
             <groupId>net.imagej</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <main-class>ijfx.ui.main.ImageJFX</main-class>
     </properties>
     
     <repositories>
@@ -231,7 +232,7 @@
                             -->
                             <classpathPrefix>lib/</classpathPrefix>
                             <!-- Configures the main class of the application -->
-                            <mainClass>ijfx.ui.main.ImageJFX</mainClass>
+                            <mainClass>${main-class}</mainClass>
                         </manifest>
                         
                         <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,41 @@
         
     </build>
     
-    
-    
+    <profiles>
+        <!--
+        The exec profile provides an easy way to execute a defined ${main-class}
+        for manual testing purposes. It is declared in a profile to avoid clashing
+        with other potential uses of exec-maven-plugin during the main build.
+        -->
+        <profile>
+            <id>exec</id>
+            <build>
+                <defaultGoal>test</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.5.0</version>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>${main-class}</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
             <version>2.0.0-rc-45-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>net.imagej</groupId>
+            <artifactId>imagej-deprecated</artifactId>
+            <version>0.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>ome</groupId>
             <artifactId>formats-api</artifactId>
             <version>5.1.8</version>


### PR DESCRIPTION
These changes fix the build, so that the code compiles on the command line, uses only release dependencies, and adds an `exec` profile so that ImageJFX can be launched using:

```
mvn -Pexec
```
